### PR TITLE
Fail build if jekyll site generation fails

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -436,5 +436,8 @@ params = CGI.parse(uri.query || "")
   def generate_jekyll_site
     puts "Building jekyll site"
     run("env PATH=$PATH bundle exec jekyll")
+    unless $? == 0
+      error "Failed to generate site with jekyll."
+    end
   end
 end


### PR DESCRIPTION
I am using your buildpack to compile a jekyll site, but while getting it setup I ran into some issues. I didn't have RedCloth in my Gemfile, which caused jekyll to fail. But it was failing silently. This change checks the return value of the jekyll step, and fails the build/push if jekyll fails.
