### PR TITLE
Show Jekyll error output

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -456,7 +456,7 @@ params = CGI.parse(uri.query || "")
 
   def generate_jekyll_site
     puts "Building jekyll site"
-    run("env PATH=$PATH bundle exec jekyll")
+    run("env PATH=$PATH bundle exec jekyll 2>&1")
     unless $? == 0
       error "Failed to generate site with jekyll."
     end


### PR DESCRIPTION
When Jekyll fails to build your site, it's very confusing when there's no error info. If it succeeds, there's no error output so nothing extra gets displayed.
