### PR TITLE
Add a more relevant README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,166 +1,73 @@
-Heroku buildpack: Ruby
-======================
+Heroku Ruby Jekyll Buildpack
+============================
 
-This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for Ruby, Rack, and Rails apps. It uses [Bundler](http://gembundler.com) for dependency management.
+Heroku Ruby Jekyll Buildpack is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for generating Ruby [Jekyll](https://github.com/mojombo/jekyll) Sites during Heroku's build/deploy.
+
+Matthew Manning created this buildpack from Heroku's [Ruby buildpack](https://github.com/heroku/heroku-buildpack-ruby) because he didn't like checking the generated _site into version control nor mixing the build and run phase and generating the site on each dyno's first request.
 
 Usage
 -----
 
-### Ruby
+Create a new Cedar-stack app with this buildpack
 
-Example Usage:
+    heroku create -s cedar --buildpack http://github.com/mattmanning/heroku-buildpack-ruby-jekyll.git
 
-    $ ls
-    Gemfile Gemfile.lock
+or add this buildpack to your current app
 
-    $ heroku create --stack cedar --buildpack http://github.com/heroku/heroku-buildpack-ruby.git
+    heroku config:add BUILDPACK_URL=http://github.com/mattmanning/heroku-buildpack-ruby-jekyll.git
 
-    $ git push heroku master
-    ...
+Create a Ruby webapp with dependencies managed by [Bundler](http://gembundler.com/) and a Jekyll site. [Heroku-Jekyll-Hello-World](https://github.com/burkemw3/Heroku-Jekyll-Hello-World) can be used as a sample starter.
+
+Push to heroku
+
+    git push heroku master
+
+Watch it "Building jekyll site"
+
+    Counting objects: 12, done.
+    Delta compression using up to 2 threads.
+    Compressing objects: 100% (8/8), done.
+    Writing objects: 100% (8/8), 1.10 KiB, done.
+    Total 8 (delta 4), reused 0 (delta 0)
+    
     -----> Heroku receiving push
-    -----> Fetching custom buildpack
-    -----> Ruby app detected
+    -----> Fetching custom build pack... done
+    -----> Ruby/Rack app detected
     -----> Installing dependencies using Bundler version 1.1.rc
-           Running: bundle install --without development:test --path vendor/bundle --deployment
-           Fetching gem metadata from http://rubygems.org/..
-           Installing rack (1.3.5)
+           Running: bundle install --without development:test --path vendor/bundle --binstubs bin/ --deployment
+           Fetching gem metadata from http://rubygems.org/.......
+           Using RedCloth (4.2.8)
+           Using posix-spawn (0.3.6)
+           Using albino (1.3.3)
+           Using fast-stemmer (1.0.0)
+           Using classifier (1.3.3)
+           Using daemons (1.1.4)
+           Using directory_watcher (1.4.1)
+           Using eventmachine (0.12.10)
+           Using kramdown (0.13.3)
+           Using liquid (2.3.0)
+           Using syntax (1.0.0)
+           Using maruku (0.6.0)
+           Using jekyll (0.11.0)
+           Using rack (1.3.5)
+           Using thin (1.3.1)
            Using bundler (1.1.rc)
            Your bundle is complete! It was installed into ./vendor/bundle
            Cleaning up the bundler cache.
+           Building jekyll site
     -----> Discovering process types
-           Procfile declares types -> (none)
-           Default types for Ruby  -> console, rake
+           Procfile declares types     -> web
+           Default types for Ruby/Rack -> console, rake
+    -----> Compiled slug size is 7.2MB
+    -----> Launching... done, v47
+    -----> Deploy hooks scheduled, check output in your logs
+           http://www.mwmanning.com deployed to Heroku
+    
+    To git@heroku.com:mattmanning.git
+       8f84bc4..9350a12  master -> master
 
-The buildpack will detect your app as Ruby if it has a `Gemfile` and `Gemfile.lock` files in the root directory. It will then proceed to run `bundle install` after setting up the appropriate environment for [ruby](http://ruby-lang.org) and [Bundler](http://gembundler.com).
+See Also
+--------
 
-#### Bundler
-
-For non-windows `Gemfile.lock` files, the `--deployment` flag will be used. In the case of windows, the Gemfile.lock will be deleted and Bundler will do a full resolve so native gems are handled properly. The `vendor/bundle` directory is cached between builds to allow for faster `bundle install` times. `bundle clean` is used to ensure no stale gems are stored between builds.
-
-### Rails 2
-
-Example Usage:
-
-    $ ls
-    app  config  db  doc  Gemfile  Gemfile.lock  lib  log  public  Rakefile  README  script  test  tmp  vendor
-
-    $ ls config/environment.rb
-    config/environment.rb
-
-    $ heroku create --stack cedar --buildpack http://github.com/heroku/heroku-buildpack-ruby.git
-
-    $ git push heroku master
-    ...
-    -----> Heroku receiving push
-    -----> Ruby/Rails app detected
-    -----> Installing dependencies using Bundler version 1.1.rc
-    ...
-    -----> Writing config/database.yml to read from DATABASE_URL
-    -----> Rails plugin injection
-           Injecting rails_log_stdout
-    -----> Discovering process types
-           Procfile declares types      -> (none)
-           Default types for Ruby/Rails -> console, rake, web, worker
-
-The buildpack will detect your app as a Rails 2 app if it has a `environment.rb` file in the `config`  directory.
-
-#### Rails Log STDOUT
-  A [rails_log_stdout](http://github.com/ddollar/rails_log_stdout) is installed by default so Rails' logger will log to STDOUT and picked up by Heroku's [logplex](http://github.com/heroku/logplex).
-
-#### Auto Injecting Plugins
-
-Any vendored plugin can be stopped from being installed by creating the directory it's installed to in the slug. For instance, to prevent rails_log_stdout plugin from being injected, add `vendor/plugins/rails_log_stdout/.gitkeep` to your git repo.
-
-### Rails 3
-
-Example Usage:
-
-    $ ls
-    app  config  config.ru  db  doc  Gemfile  Gemfile.lock  lib  log  Procfile  public  Rakefile  README  script  tmp  vendor
-
-    $ ls config/application.rb
-    config/application.rb
-
-    $ heroku create --stack cedar --buildpack http://github.com/heroku/heroku-buildpack-ruby.git
-
-    $ git push heroku master
-    -----> Heroku receiving push
-    -----> Ruby/Rails app detected
-    -----> Installing dependencies using Bundler version 1.1.rc
-           Running: bundle install --without development:test --path vendor/bundle --deployment
-           ...
-    -----> Writing config/database.yml to read from DATABASE_URL
-    -----> Preparing app for Rails asset pipeline
-           Running: rake assets:precompile
-    -----> Rails plugin injection
-           Injecting rails_log_stdout
-           Injecting rails3_serve_static_assets
-    -----> Discovering process types
-           Procfile declares types      -> web
-           Default types for Ruby/Rails -> console, rake, worker
-
-The buildpack will detect your apps as a Rails 3 app if it has an `application.rb` file in the `config` directory.
-
-#### Assets
-
-To enable static assets being served on the dyno, [rails3_serve_static_assets](http://github.com/pedro/rails3_serve_static_assets) is installed by default. If the [execjs gem](http://github.com/sstephenson/execjs) is detected then [node.js](http://github.com/joyent/node) will be vendored. The `assets:precompile` rake task will get run if no `public/manifest.yml` is detected.  See [this article](http://devcenter.heroku.com/articles/rails31_heroku_cedar) on how rails 3.1 works on cedar.
-
-Hacking
--------
-
-To use this buildpack, fork it on Github.  Push up changes to your fork, then create a test app with `--buildpack <your-github-url>` and push to it.
-
-To change the vendored binaries for Bundler, [Node.js](http://github.com/joyent/node), and rails plugins, use the rake tasks provided by the `Rakefile`. You'll need an S3-enabled AWS account and a bucket to store your binaries in as well as the [vulcan](http://github.com/ddollar/vulcan) gem to build the binaries on heroku.
-
-For example, you can change the vendored version of Bundler to 1.1.rc.
-
-First you'll need to build a Heroku-compatible version of Node.js:
-
-    $ export AWS_ID=xxx AWS_SECRET=yyy S3_BUCKET=zzz
-    $ s3 create $S3_BUCKET
-    $ rake gem:install[bundler,1.1.rc]
-
-Open `lib/language_pack/ruby.rb` in your editor, and change the following line:
-
-    BUNDLER_VERSION = "1.1.rc"
-
-Open `lib/language_pack/base.rb` in your editor, and change the following line:
-
-    VENDOR_URL = "https://s3.amazonaws.com/zzz"
-
-Commit and push the changes to your buildpack to your Github fork, then push your sample app to Heroku to test.  You should see:
-
-    -----> Installing dependencies using Bundler version 1.1.rc
-
-NOTE: You'll need to vendor the plugins, node, Bundler, and libyaml by running the rake tasks for the buildpack to work properly.
-
-Flow
-----
-
-Here's the basic flow of how the buildpack works:
-
-Ruby (Gemfile and Gemfile.lock is detected)
-
-* runs Bundler
-* installs binaries
-  * installs node if the gem execjs is detected
-* runs `rake assets:precompile` if the rake task is detected
-
-Rack (config.ru is detected)
-
-* everything from Ruby
-* sets RACK_ENV=production
-
-Rails 2 (config/environment.rb is detected)
-
-* everything from Rack
-* sets RAILS_ENV=production
-* install rails 2 plugins
-  * [rails_log_stdout](http://github.com/ddollar/rails_log_stdout)
-
-Rails 3 (config/application.rb is detected)
-
-* everything from Rails 2
-* install rails 3 plugins
-  * [rails3_server_static_assets](https://github.com/pedro/rails3_serve_static_assets)
+Matthew Manning introduced the build pack on his blog: [http://mwmanning.com/2011/11/29/Run-Your-Jekyll-Site-On-Heroku.html](http://mwmanning.com/2011/11/29/Run-Your-Jekyll-Site-On-Heroku.html).
 


### PR DESCRIPTION
I wanted to add a more relevant readme file for your great buildpack and finally got around to it.

This might be annoying for upstream changes to the readme. It will provide good information to new people that stumble upon the buildpack, though.
