### PR TITLE
Pipe errors from jeyll compilation

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -578,7 +578,7 @@ params = CGI.parse(uri.query || "")
 
   def generate_jekyll_site
     puts "Building jekyll site"
-    run("env PATH=$PATH bundle exec jekyll 2>&1")
+    pipe("env PATH=$PATH bundle exec jekyll 2>&1")
     unless $? == 0
       error "Failed to generate site with jekyll."
     end


### PR DESCRIPTION
Hi @mattmanning,

I had a hard time trying to make it work on Heroku, the jekyll compilation failed. So I forked your repo and piped the jekyll compilation back to the user and figured out I was missing jgarber/redcloth in my `Gemfile`.

I guess that could help some other users in the future.

Cheers.
