### PR TITLE
Stop jekyll running server or monitoring for changes.

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -578,7 +578,7 @@ params = CGI.parse(uri.query || "")
 
   def generate_jekyll_site
     puts "Building jekyll site"
-    run("env PATH=$PATH bundle exec jekyll 2>&1")
+    run("env PATH=$PATH bundle exec jekyll --no-server --no-auto 2>&1")
     unless $? == 0
       error "Failed to generate site with jekyll."
     end


### PR DESCRIPTION
Stops jekyll from running a server or automatically rebuilding on a change, both of which cause the process to keep running.
