### PR TITLE
Jekyll Update.  Build Failure

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -597,7 +597,7 @@ params = CGI.parse(uri.query || "")
 
   def generate_jekyll_site
     puts "Building jekyll site"
-    pipe("env PATH=$PATH bundle exec jekyll --no-server --no-auto 2>&1")
+    pipe("env PATH=$PATH bundle exec jekyll build 2>&1")
     unless $? == 0
       error "Failed to generate site with jekyll."
     end


### PR DESCRIPTION
 Building jekyll site
              Deprecation: Jekyll now uses subcommands instead of just switches. Run `jekyll help' to find out more.
              Deprecation: To build Jekyll without launching a server, use the 'build' subcommand.
              Deprecation: To disable auto-replication, simply leave off the '--watch' switch.
       invalid option: --no-server
 !
 !     Failed to generate site with jekyll.
